### PR TITLE
プラグインのバージョンアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
@@ -223,7 +228,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -241,6 +246,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -257,7 +263,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.5.0</version>
         <configuration>
           <!-- MANIFEST.MFでClass-Pathを指定すると、依存jar内で定義されているtaglibのuriを正しく解決してくれない。 -->
           <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -278,6 +284,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
## 修正内容
Nablarch 6移行に伴い、以下のプラグイン定義を最新化した。
最低Mavenのバージョンが[解説書](https://nablarch.github.io/docs/6-LATEST/doc/application_framework/application_framework/blank_project/beforeFirstStep.html#firststeppreamble)で案内している`3.6.3`と乖離がないよう確認した。

- maven-compilier-plugin：`3.13.0`に最新化
最低Mavenバージョンは`3.6.3`（[参考](https://github.com/apache/maven-compiler-plugin/releases#:~:text=MCOMPILER%2D583%5D%20%2D-,Require%20Maven%203.6.3,-(%23229))）
本Exampleで元々バージョンの定義はされていなかったため、使用しているMavenのバージョンで自動で定義されていた。
他のExampleと統一するため`3.13.0`で定義した。

- build-helper-maven-plugin：`3.6.0`に最新化
最低Mavenバージョンは`3.6.3`（[参考](https://www.mojohaus.org/build-helper-maven-plugin/plugin-info.html#system-requirements-history)）

- maven-jar-plugin：`3.4.2`に最新化
最低Mavenバージョンは`3.6.3`（[参考](https://maven.apache.org/plugins/maven-jar-plugin/plugin-info.html)）


- maven-surefire-plugin：`3.5.0`に最新化
最低Mavenバージョンは`3.6.3`（[参考](https://maven.apache.org/surefire/maven-surefire-plugin/plugin-info.html#system-requirements-history)）

- maven-assembly-plugin：`3.7.1`に最新化
最低Mavenバージョンは`3.6.3`（[参考](https://maven.apache.org/plugins/maven-assembly-plugin/plugin-info.html)）


## 動作確認
動作確認はMavenのバージョン`3.9.9`を使用して行った。
- [x] `mvn test`が成功すること
  - [x] `/target/surefire-reports`にレポートが生成されること
- [x] Readme通り動作すること
- [x] 今回の修正でログに警告が増えていないこと 